### PR TITLE
Fix public path issue

### DIFF
--- a/src/Themonkeys/Cachebuster/AssetURLGenerator.php
+++ b/src/Themonkeys/Cachebuster/AssetURLGenerator.php
@@ -76,7 +76,7 @@ class AssetURLGenerator
         if (File::exists($url)) {
             $source = File::get($url);
             $base = realpath(dirname($url));
-            $public = realpath('./');
+            $public = realpath(DIRECTORY_SEPARATOR . public_path());
 
             // search for url('*') and replace with processed url
             $self = $this;


### PR DESCRIPTION
Resolved public path issue with OSX and Laravel web server.

Instead of using .htaccess rules, the following can be used in your routes file. However, the path issue meant it was trying to access the wrong path. 

/*\* 
- CACHE BUSTERS
  */

Route::pattern('hash', '[a-zA-Z0-9]+');
Route::pattern('allowedExtensions', '(jpg|png|gif|js|css){1}');
Route::pattern('folders', '[a-zA-Z0-9_\/]*');
Route::pattern('fileName', '[a-zA-Z0-9]+');

App::make('cachebuster.StripSessionCookiesFilter')->addPattern('|css/|');

Route::get(
    'assets/{folders}{fileName}-{hash}.{allowedExtensions}', array(
        function($folders, $fileName, $hash, $extension)
        {
            $shortPath = 'assets' . DIRECTORY_SEPARATOR . $folders . $fileName . '.' . $extension;
            $path = public_path() . DIRECTORY_SEPARATOR . $shortPath;

```
        if (!file_exists($path)) {
            return App::abort(404);
        }

        $headers = [
            'content-type' => 'text/' . $extension, 
            'Cache-Control' => 'max-age=31536000',
            'Pragma' => 'cache',
            'Expires' => 'Sun, 17 Jan 2038 19:14:07 GMT'
        ];

        if (strtolower($extension) == 'css') {
            return Response::make(Bust::css($shortPath), 200, $headers);
        }

        return Response::make(file_get_contents($path), 200, $headers);
    }
)
```

);
