### PR TITLE
Added the option for adding the md5 sum as a version subfix

### DIFF
--- a/src/Themonkeys/Cachebuster/AssetURLGenerator.php
+++ b/src/Themonkeys/Cachebuster/AssetURLGenerator.php
@@ -17,17 +17,29 @@ class AssetURLGenerator
     /**
      * Returns a full URL to the given asset. For example, on production passing '/css/main.css' may return
      * http://a1bc23de4fgh5i.cloudfront.net/css/main-8b50d865ef2e3469be477e2745c888c5.css
+     * or
+     * http://a1bc23de4fgh5i.cloudfront.net/css/main.css?v=8b50d865ef2e3469be477e2745c888c5
      *
-     * @param $asset
+     * @param  string  $asset
+     * @param  boolean $absolute
+     * @param  boolean $useSubfix
+     *
+     * @return string
      */
-    public function url($asset, $absolute = false) {
-        $url = $this->cachebusted($asset);
-
+    public function url($asset, $absolute = false, $useSubfix = false) {
         $base = Config::get("cachebuster.cdn");
+
         if ($base === '' && $absolute) {
             $base = URL::to('/');
         }
-        return $base . $url;
+
+        if (Config::get("cachebuster.use_subfix") || $useSubfix) {
+            return "{$base}{$asset}?v={$this->md5($asset)}";
+        }
+
+        $url = $this->cachebusted($asset);
+
+        return "{$base}{$url}";
     }
 
     public function cachebusted($asset) {
@@ -36,7 +48,7 @@ class AssetURLGenerator
         if (Config::get("cachebuster.enabled")) {
             $md5 = $this->md5($url);
 
-        
+
             if ($md5) {
                 $parts = pathinfo($url);
                 $dirname = ends_with($parts['dirname'], '/') ? $parts['dirname'] : $parts['dirname'] . '/';

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -64,4 +64,16 @@ return array(
     */
     'enabled' => env('CACHEBUSTER_ENABLED', false),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Enable or disable cachebusting as subfix
+    |--------------------------------------------------------------------------
+    |
+    | A subfix with the file md5 is added instead of re-writing the assist
+    | filename
+    |
+    | Example:
+    | http://exmaple.com/js/main.js?v=40f29f23d7a1525411f3b9583d5d4ee6
+    */
+    'use_subfix' => env('CACHEBUSTER_USE_SUBFIX', false),
 );


### PR DESCRIPTION
In my projects it is not a valid option to "re-write" the filename if the asset request. The cashbusting works much better if the filename is intact and instead subfixed with a query param containing the md5 sum of the file.

Have added this as a "global" option in the config file and also for each individual asset file.

Has been proven to work very nicely with cloudflare. 
