### PR TITLE
Allow it to be installed with Laravel 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.*|5.*",
-        "symfony/http-kernel": "2.*"
+        "symfony/http-kernel": "2.*|3.*"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Laravel 5.3 requires symfony/http-kernel 3.1.*